### PR TITLE
Allow region to be passed as argument.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -18,6 +18,7 @@ var args = minimist(process.argv.slice(2), {
     'delete-removed': false,
     'max-sockets': 30,
     'insecure': false,
+    'region': 'us-east-1'
   },
   'boolean': [
     'recursive',
@@ -65,6 +66,7 @@ fs.readFile(args.config, {encoding: 'utf8'}, function(err, contents) {
       accessKeyId: accessKeyId,
       secretAccessKey: secretAccessKey,
       sslEnabled: !args.insecure,
+      region: args.region,
     },
   });
   var cmd = args._.shift();


### PR DESCRIPTION
I have a bucket in the US West (Oregon) region. When attempting to upload files to this bucket, I would get the following exception:

```
/home/mloar/devel/belltowncrime/node_modules/s3-cli/node_modules/s3/node_modules/aws-sdk/lib/request.js:34
        throw e;
              ^
PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.
    at Request.extractError (/home/mloar/devel/belltowncrime/node_modules/s3-cli/node_modules/s3/node_modules/aws-sdk/lib/services/s3.js:257:35)
```

This pull request adds region as an argument and passes it to aws-sdk in the config, allowing it to select the correct endpoint.
