### PR TITLE
Add support for HTTP(S) proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
   "author": "Andrew Kelley <superjoe30@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "https-proxy-agent": "^1.0.0",
+    "human-size": "~1.1.0",
     "ini": "~1.2.1",
     "minimist": "~1.1.0",
     "osenv": "~0.1.0",
-    "s3": "~4.2.0",
-    "human-size": "~1.1.0"
+    "s3": "~4.2.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
For compatibility with s3cmd, supports configuring a proxy using the `proxy_host` and `proxy_port` INI settings.

Example:

```
[default]
access_key = *****
access_token =
proxy_host = 192.168.1.100
proxy_port = 8080
```